### PR TITLE
Add proper type exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "./dist/index.js",
   "repository": "https://github.com/dkress59/wordpress-api-client",
-  "types": "./src/index.ts",
+  "types": "./dist/index.d.ts",
   "contributors": [
     {
       "name": "Damian Kress",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,6 @@
 		"skipLibCheck": true,
 		"strict": true,
 		"target": "esnext",
+		"declaration": true
 	}
 }


### PR DESCRIPTION
 Add `.d.ts` exports and point the `package.json`'s"types" to it so that internal type errors don't bubble up into consumers type checks.

Interal type errors can be seen by turning `noUncheckedIndexedAccess` on giving an output like:
```
$ /.../app/node_modules/.bin/tsc
node_modules/wordpress-api-client/src/util.ts:27:3 - error TS2322: Type 'string | undefined' is not assignable to type 'string'.
  Type 'undefined' is not assignable to type 'string'.

27   return (json as { message: string[] }).message[0]
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 1 error in node_modules/wordpress-api-client/src/util.ts:27
```

The compiler option `skipLibCheck` disables checking `.d.ts` for node_modules to fix this exact issue, but since you pointed types to the actual `.ts` files it ignored that setting.